### PR TITLE
v3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # BlurHash Changelog
 
+## 3.0.4 - 2025-03-20
+
+- Updated: Added support for HEIC images. Fixes [#24](https://github.com/dodecastudio/craft-blurhash/issues/24) - thanks to @VincentSmackIt for raising.
+- Fixed: Minor change to some syntax introduced in 3.0.2 to better support older versions of PHP.
+
 ## 3.0.3 - 2024-12-10
 
 - Updated: Further simplified checking whether a file exists or not, removing superfluous code. Related to [#22](https://github.com/dodecastudio/craft-blurhash/issues/22).

--- a/blurhash-config.php
+++ b/blurhash-config.php
@@ -43,7 +43,7 @@ return [
   /**
    * @var array An array of bitmap mime-types allowed by blurhash. 
    */
-  'allowedFileTypes' => ['image/jpeg', 'image/png', 'image/webp'],
+  'allowedFileTypes' => ['image/jpeg', 'image/png', 'image/webp', 'image/tiff', 'image/bmp', 'image/gif', 'image/avif', 'image/heic'],
   
   /**
    * @var bool Whether or not to check that the asset file exists when rendering the blurhash.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "dodecastudio/craft-blurhash",
   "description": "Render a BlurHash from a given image.",
   "type": "craft-plugin",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "license": "proprietary",
   "keywords": [
     "craft",

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -14,7 +14,7 @@ class Settings extends Model
     public $sampleMaxImageSize = 64;
 
     // Allowed image types.
-    public $allowedFileTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/tiff', 'image/bmp', 'image/gif'];
+    public $allowedFileTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/tiff', 'image/bmp', 'image/gif', 'image/avif', 'image/heic'];
 
     // Whether or not to check that the asset is valid.
     public $checkFileExists = true;


### PR DESCRIPTION
- Updated: Added support for HEIC images. Fixes [#24](https://github.com/dodecastudio/craft-blurhash/issues/24) - thanks to @VincentSmackIt for raising.
- Fixed: Minor change to some syntax introduced in 3.0.2 to better support older versions of PHP.