### PR TITLE
fix: check on mimetype

### DIFF
--- a/src/services/BlurHashService.php
+++ b/src/services/BlurHashService.php
@@ -130,6 +130,7 @@ class BlurHashService extends Component
             return $cachedValue;
             
         } else {
+            $typesToTransform = ["image/heic"];
 
             $sampleImageWidth = round($sampleSize * ($asset->width > $asset->height ? 1 : $asset->width / $asset->height));
             $sampleImageHeight = round($sampleSize * ($asset->height > $asset->width ? 1 : $asset->height / $asset->width));
@@ -137,7 +138,8 @@ class BlurHashService extends Component
             $thumbnailImage = imagecreatetruecolor($sampleImageWidth, $sampleImageHeight); 
 
             $assetContents = $asset->getContents();
-            if ($asset->getExtension() === 'heic') {
+            
+            if (in_array($asset->mimeType, $typesToTransform)) {
                 $imagick = new \Imagick();
                 $imagick->readImageBlob($assetContents);
                 $imagick->setImageFormat('png');


### PR DESCRIPTION
Currently the check is on extension and HEIC is in full caps when dumping that extension.
Changed the check to mimetype and added an array to support more types later on, if needed.

Fixes the below error
<img width="1139" height="882" alt="Screenshot 2025-10-08 at 11 25 01" src="https://github.com/user-attachments/assets/7ba1867e-5481-4988-bd06-3ba5baf2b432" />
